### PR TITLE
Adding go.uber.org/zap

### DIFF
--- a/sally.yaml
+++ b/sally.yaml
@@ -13,3 +13,5 @@ packages:
         repo: github.com/uber-go/sally
     fx:
         repo: github.com/uber-go/uberfx
+    zap:
+        repo: github.com/uber-go/zap


### PR DESCRIPTION
This PR will diverge Github Pages from GCE and allow me to test cache and the DNS switch.