### PR TITLE
Sort packages alphabetically in sally.yml

### DIFF
--- a/sally.yaml
+++ b/sally.yaml
@@ -3,15 +3,15 @@
 url: go.uber.org
 
 packages:
-    yarpc:
-        repo: github.com/yarpc/yarpc-go
-    thriftrw:
-        repo: github.com/thriftrw/thriftrw-go
+    fx:
+        repo: github.com/uber-go/uberfx
     ratelimit:
         repo: github.com/uber-go/ratelimit
     sally:
         repo: github.com/uber-go/sally
-    fx:
-        repo: github.com/uber-go/uberfx
+    thriftrw:
+        repo: github.com/thriftrw/thriftrw-go
+    yarpc:
+        repo: github.com/yarpc/yarpc-go
     zap:
         repo: github.com/uber-go/zap

--- a/sally.yaml
+++ b/sally.yaml
@@ -3,6 +3,8 @@
 url: go.uber.org
 
 packages:
+    atomic:
+        repo: github.com/uber-go/atomic
     fx:
         repo: github.com/uber-go/uberfx
     ratelimit:


### PR DESCRIPTION
We might want to add a `sally lint` option that returns errors if the packages are not sorted, and use that as a pre-submit rule in Travis for this repo.