### PR TITLE
Upgrade to latest Google App Engine Flexible

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,2 +1,2 @@
 runtime: custom
-vm: true
+env: flex

--- a/sally.yaml
+++ b/sally.yaml
@@ -11,6 +11,8 @@ packages:
         repo: github.com/uber-go/ratelimit
     sally:
         repo: github.com/uber-go/sally
+    test:
+        repo: github.com/uber-go/sally
     thriftrw:
         repo: github.com/thriftrw/thriftrw-go
     yarpc:


### PR DESCRIPTION
This repo uses GAE Flexible in order to customize its runtime using a `Dockerfile`.

While mature, the runtime is still in Beta. They recently published an update to the platform that requires some changes (see upgrade guide [here](https://cloud.google.com/appengine/docs/flexible/python/upgrading)).

Mainly:

1. Update `app.yaml` to use new format
2. Request whitelisting for custom domains

As for #2, they are moving flexible runtimes from app.appspot.com to app.appspot-preview.com. 

This can be handled seamlessly as long as you request the whitelisting before doing a deploy, which I have done already:

<img width="1072" alt="screen shot 2017-01-11 at 8 02 58 pm" src="https://cloud.githubusercontent.com/assets/263587/21876590/fdf53a60-d838-11e6-8c16-54b0f10f5015.png">



Additionally, I've tested this migration out with another GAE Flexible account here https://github.com/breerly/hellogo/commit/1ddf7ad9d74b24d32bc6b704785547487c89d318, so I don't foresee any issues.

Regardless, I'm waiting till evening time to do this since traffic is near 0:

<img width="1626" alt="screen shot 2017-01-11 at 7 57 22 pm" src="https://cloud.githubusercontent.com/assets/263587/21876477/32b4ca8c-d838-11e6-9cd3-c4a52883ef0e.png">

If there are issues, I'll roll the deploy back to a previously known good state.