### PR TITLE
Add go.uber.org/multierr

### DIFF
--- a/sally.yaml
+++ b/sally.yaml
@@ -7,6 +7,8 @@ packages:
         repo: github.com/uber-go/atomic
     fx:
         repo: github.com/uber-go/fx
+    multierr:
+        repo: github.com/uber-go/multierr
     ratelimit:
         repo: github.com/uber-go/ratelimit
     sally:


### PR DESCRIPTION
The repo isn't public yet but it's only a matter of time.