### PR TITLE
Add go.uber.org/cadence

### DIFF
--- a/sally.yaml
+++ b/sally.yaml
@@ -5,6 +5,8 @@ url: go.uber.org
 packages:
     atomic:
         repo: github.com/uber-go/atomic
+    cadence:
+        repo: github.com/uber-go/cadence-client
     dig:
         repo: github.com/uber-go/dig
     fx:


### PR DESCRIPTION
Replacing https://github.com/uber/go.uber.org/pull/23 which was opened from @sivakku's personal Github instead of a branch pushed to this repo.