### PR TITLE
Adding go.uber.org/config

### DIFF
--- a/sally.yaml
+++ b/sally.yaml
@@ -7,6 +7,8 @@ packages:
         repo: github.com/uber-go/atomic
     cadence:
         repo: github.com/uber-go/cadence-client
+    config:
+        repo: github.com/uber-go/config
     dig:
         repo: github.com/uber-go/dig
     fx:


### PR DESCRIPTION
The Fx project is breaking out the config package which has been incubating in go.uber.org/fx.