### PR TITLE
Add contribution guidelines to go.uber.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Before a project can be included here it must meet several criteria:
   no backwards-incompatible changes).
 
 * Maintained. The project should at all times have well-defined owners who are
-  comitteted to addressing issues on the project.
+  committed to addressing issues on the project.
 
 Projects already listed on `go.uber.org` but not meeting these criteria may be
 removed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contribution Guidelines
+
+The `go.uber.org` domain is meant to host stable, high-quality, well-maintained
+Go libraries developed by Uber Technologies Inc..
+
+Adding a new project to the domain can be done by inserting an entry in `sally.yaml`.
+
+Before a project can be included here it must meet several criteria:
+
+* High quality. Test coverage for the project should be at least 90% with a
+  badge included in `README.md`. We recommend [codecov.io](http://codecov.io/).
+
+* Stable. The project should be tagged according to a *strict* interpretation
+  of [SemVer 2.0](http://semver.org). The project should be on a `1.x` branch,
+  with a commitment to a minimum of one year between major version bumps (i.e.,
+  no backwards-incompatible changes).
+
+* Maintained. The project should at all times have well-defined owners who are
+  comitteted to addressing issues on the project.
+
+Projects already listed on `go.uber.org` but not meeting these criteria may be
+removed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contribution Guidelines
 
 The `go.uber.org` domain is meant to host stable, high-quality, well-maintained
-Go libraries developed by Uber Technologies Inc..
+Go libraries developed by Uber Technologies, Inc.
 
 Adding a new project to the domain can be done by inserting an entry in `sally.yaml`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@ Before a project can be included here it must meet several criteria:
   badge included in `README.md`. We recommend [codecov.io](http://codecov.io/).
 
 * Stable. The project should be tagged according to a *strict* interpretation
-  of [SemVer 2.0](http://semver.org). The project should be on a `1.x` branch,
-  with a commitment to a minimum of one year between major version bumps (i.e.,
-  no backwards-incompatible changes).
+  of [SemVer 2.0](http://semver.org). The project should have at least a
+  "v1.0.0" tag, with a commitment to a minimum of one year between major
+  version bumps (i.e., no backwards-incompatible changes).
 
 * Maintained. The project should at all times have well-defined owners who are
   committed to addressing issues on the project.


### PR DESCRIPTION
This establishes the minimum bar we expect projects to meet before being listed under the `go.uber.org` domain.

If you have wordsmithing feedback please feel welcome to push commits on top.