### PR TITLE
Add net/metrics

### DIFF
--- a/sally.yaml
+++ b/sally.yaml
@@ -15,6 +15,8 @@ packages:
         repo: github.com/uber-go/dig
     fx:
         repo: github.com/uber-go/fx
+    net/metrics:
+        repo: github.com/yarpc/metrics
     multierr:
         repo: github.com/uber-go/multierr
     ratelimit:

--- a/sally.yaml
+++ b/sally.yaml
@@ -15,10 +15,10 @@ packages:
         repo: github.com/uber-go/dig
     fx:
         repo: github.com/uber-go/fx
-    net/metrics:
-        repo: github.com/yarpc/metrics
     multierr:
         repo: github.com/uber-go/multierr
+    net/metrics:
+        repo: github.com/yarpc/metrics
     ratelimit:
         repo: github.com/uber-go/ratelimit
     sally:


### PR DESCRIPTION
Add `go.uber.org/net/metrics` as a vanity import path for
`github.com/yarpc/metrics`.