### PR TITLE
Upgrade to Go 1.11

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+language: go
 sudo: required
 
 services:
   - docker
 
-language: go
+go: 1.11
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_a8a6a38f04c1_key -iv $encrypted_a8a6a38f04c1_iv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM golang:1.11
 ADD . app/
 WORKDIR app/
 RUN make install

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+export GO111MODULE=on
+
 .PHONY: install
 install:
-	go get go.uber.org/sally
-
+	go install go.uber.org/sally
 
 .PHONY: run
 run:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/uber/go.uber.org
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/julienschmidt/httprouter v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8 // indirect
+	go.uber.org/sally v0.0.0-20170131234729-d7723f129c89
+	golang.org/x/net v0.0.0-20181220203305-927f97764cc3 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+9HbQbYf7g=
+github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8 h1:OlIHDBRrlQk8fHa662oG2gzOO/ixBRU9sLht/M9kzK0=
+github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8/go.mod h1:+ccdNT0xMY1dtc5XBxumbYfOUhmduiGudqaDgD2rVRE=
+go.uber.org/sally v0.0.0-20170131234729-d7723f129c89 h1:RrYgBQ8ORFvGv5P94VGatugBzD0kcmWcKweGF/ec2f8=
+go.uber.org/sally v0.0.0-20170131234729-d7723f129c89/go.mod h1:eox+skEE8OZPR5T9NzQYEgzzCT8atydA7pxPYh2UKGY=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3 h1:eH6Eip3UpmR+yM/qI9Ijluzb1bNv/cAU/n+6l8tRSis=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,5 @@
+// +build tools
+
+package main
+
+import _ "go.uber.org/sally"


### PR DESCRIPTION
Thisn upgrades go.uber.org to Go 1.11, relying on Go modules to get
dependencies rather than always fetching sally master.

To avoid unintentionally picking up new changes to Sally, I explicitly
requested https://github.com/uber-go/sally/commits/d7723f1 because
that's the version of sally currently deployed.

Note that this DOES NOT switch to the GAE "go111" runtime
(https://blog.golang.org/appengine-go111), sticking with "custom". That
migration is a riskier change that I would like to defer.