### PR TITLE
Add go.uber.org/mock

### DIFF
--- a/sally.yaml
+++ b/sally.yaml
@@ -24,6 +24,9 @@ packages:
     goleak:
         repo: github.com/uber-go/goleak
         description: A goroutine leak detection library.
+    mock:
+        repo: github.com/uber/mock
+        description: A mocking framework for Go.
     multierr:
         repo: github.com/uber-go/multierr
         description: A library for combining one or more Go errors together.


### PR DESCRIPTION
This adds go.uber.org/mock project for redirection.