### PR TITLE
Add alias for NilAway

### DIFF
--- a/sally.yaml
+++ b/sally.yaml
@@ -54,3 +54,6 @@ packages:
     zap:
         repo: github.com/uber-go/zap
         description: Blazing fast, structured, leveled logging in Go.
+    nilaway:
+        repo: github.com/uber-go/nilaway
+        description: A static analysis tool for detecting potential nil panics in Go.


### PR DESCRIPTION
This PR adds an alias for the newly-open-sourced NilAway project: https://github.com/uber-go/nilaway